### PR TITLE
このリポジトリのホームページをgemspecに追加した

### DIFF
--- a/geekbot.gemspec
+++ b/geekbot.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Geekbot API client library, written in Ruby'
   spec.description   = 'Geekbot API client library, written in Ruby'
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = 'https://github.com/standfirm/geekbot_ruby'
   spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'


### PR DESCRIPTION
## :sparkles: 目的

Railsアプリケーションにこのgemをインストールしようとすると、ホームページが設定されていない旨の警告が出る。これを回避する。

## :muscle: 方針

gemspecにホームページを追加する。

## :white_check_mark: テスト

とりあえず入れる。